### PR TITLE
hotfix for DateOnlyConverter

### DIFF
--- a/src/Utilities/Converters/DateOnlyConverter.cs
+++ b/src/Utilities/Converters/DateOnlyConverter.cs
@@ -21,8 +21,8 @@ public class DateOnlyConverter : JsonConverter<DateOnly>
         return DateOnly.ParseExact(
             reader.GetString() ?? string.Empty,
             DatePattern,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal);
+            CultureInfo.InvariantCulture
+            );
     }
 
     /// <summary>Writes a specified value as JSON.</summary>


### PR DESCRIPTION
* remove assume universal from dateonly, it doesn't work when parsing requests in aspnetcore apps